### PR TITLE
Jf 129 add auto generate swagger docs

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -8,7 +8,6 @@
 	<packaging>jar</packaging>
 	<version>3.0</version>
 	<properties>
-		<java.version>1.8</java.version>
 		<swagger2markup.version>1.2.0</swagger2markup.version>
 		<swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
 		<documentation.directory>${project.build.directory}/docs</documentation.directory>
@@ -16,8 +15,6 @@
 		<html.directory>${documentation.directory}/html</html.directory>
 		<pdf.directory>${documentation.directory}/pdf</pdf.directory>
 		<swagger.input>${swagger.output.dir}/swagger.json</swagger.input>
-		<jackson.version>2.9.6</jackson.version>
-		<springfox.version>2.9.2</springfox.version>
 	</properties>
 	<pluginRepositories>
 		<pluginRepository>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -88,13 +88,33 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.1.0</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-engine</artifactId>
-			<scope>test</scope>
-		</dependency>
+	<dependency>
+		<groupId>org.junit.jupiter</groupId>
+		<artifactId>junit-jupiter-engine</artifactId>
+		<version>5.1.0</version>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.junit.vintage</groupId>
+		<artifactId>junit-vintage-engine</artifactId>
+		<version>5.1.0</version>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.junit.platform</groupId>
+		<artifactId>junit-platform-launcher</artifactId>
+		<version>1.1.0</version>
+		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>org.junit.platform</groupId>
+		<artifactId>junit-platform-runner</artifactId>
+		<version>1.1.0</version>
+		<scope>test</scope>
+	</dependency>
 		<!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-test -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -109,5 +129,7 @@
 			<artifactId>unirest-java</artifactId>
 			<version>1.4.9</version>
 		</dependency>
+
+
 	</dependencies>
 </project>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -7,6 +7,21 @@
 	<artifactId>locationReciever</artifactId>
 	<packaging>jar</packaging>
 	<version>3.0</version>
+	<properties>
+		<java.version>1.8</java.version>
+		<swagger2markup.version>1.2.0</swagger2markup.version>
+		<asciidoctor.input.directory>${project.basedir}/src/docs/asciidoc</asciidoctor.input.directory>
+
+		<swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
+		<swagger.snippetOutput.dir>${project.build.directory}/asciidoc/snippets</swagger.snippetOutput.dir>
+		<generated.asciidoc.directory>${project.build.directory}/asciidoc/generated</generated.asciidoc.directory>
+		<asciidoctor.html.output.directory>${project.build.directory}/asciidoc/html</asciidoctor.html.output.directory>
+		<asciidoctor.pdf.output.directory>${project.build.directory}/asciidoc/pdf</asciidoctor.pdf.output.directory>
+
+		<swagger.input>${swagger.output.dir}/swagger.json</swagger.input>
+		<jackson.version>2.9.6</jackson.version>
+		<springfox.version>2.9.2</springfox.version>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -10,18 +10,31 @@
 	<properties>
 		<java.version>1.8</java.version>
 		<swagger2markup.version>1.2.0</swagger2markup.version>
-		<asciidoctor.input.directory>${project.basedir}/src/docs/asciidoc</asciidoctor.input.directory>
-
 		<swagger.output.dir>${project.build.directory}/swagger</swagger.output.dir>
-		<swagger.snippetOutput.dir>${project.build.directory}/asciidoc/snippets</swagger.snippetOutput.dir>
-		<generated.asciidoc.directory>${project.build.directory}/asciidoc/generated</generated.asciidoc.directory>
-		<asciidoctor.html.output.directory>${project.build.directory}/asciidoc/html</asciidoctor.html.output.directory>
-		<asciidoctor.pdf.output.directory>${project.build.directory}/asciidoc/pdf</asciidoctor.pdf.output.directory>
-
+		<documentation.directory>${project.build.directory}/docs</documentation.directory>
+		<asciidoc.directory>${documentation.directory}/asciidoc</asciidoc.directory>
+		<html.directory>${documentation.directory}/html</html.directory>
+		<pdf.directory>${documentation.directory}/pdf</pdf.directory>
 		<swagger.input>${swagger.output.dir}/swagger.json</swagger.input>
 		<jackson.version>2.9.6</jackson.version>
 		<springfox.version>2.9.2</springfox.version>
 	</properties>
+	<pluginRepositories>
+		<pluginRepository>
+			<id>jcenter-snapshots</id>
+			<name>jcenter</name>
+			<url>http://oss.jfrog.org/artifactory/oss-snapshot-local/</url>
+		</pluginRepository>
+		<pluginRepository>
+			<id>jcenter-releases</id>
+			<name>jcenter</name>
+			<url>http://jcenter.bintray.com</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+	</pluginRepositories>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -47,6 +60,93 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>3.0.0-M1</version>
+			</plugin>
+			<!-- First, use the swagger2markup plugin to generate asciidoc -->
+			<plugin>
+				<groupId>io.github.swagger2markup</groupId>
+				<artifactId>swagger2markup-maven-plugin</artifactId>
+				<version>${swagger2markup.version}</version>
+				<dependencies>
+					<dependency>
+						<groupId>io.github.swagger2markup</groupId>
+						<artifactId>swagger2markup-import-files-ext</artifactId>
+						<version>${swagger2markup.version}</version>
+					</dependency>
+					<dependency>
+						<groupId>io.github.swagger2markup</groupId>
+						<artifactId>swagger2markup-spring-restdocs-ext</artifactId>
+						<version>${swagger2markup.version}</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+					<swaggerInput>${swagger.input}</swaggerInput>
+					<outputFile>${asciidoc.directory}/ApiDocumentation</outputFile>
+					<config>
+						<swagger2markup.markupLanguage>ASCIIDOC</swagger2markup.markupLanguage>
+						<swagger2markup.pathsGroupedBy>TAGS</swagger2markup.pathsGroupedBy>
+					</config>
+				</configuration>
+				<executions>
+					<execution>
+						<phase>test</phase>
+						<goals>
+							<goal>convertSwagger2markup</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- Run the generated asciidoc through Asciidoctor to generate
+                other documentation types, such as PDFs or HTML5 -->
+			<plugin>
+				<groupId>org.asciidoctor</groupId>
+				<artifactId>asciidoctor-maven-plugin</artifactId>
+				<version>1.5.6</version>
+				<!-- Include Asciidoctor PDF for pdf generation -->
+				<dependencies>
+					<dependency>
+						<groupId>org.asciidoctor</groupId>
+						<artifactId>asciidoctorj-pdf</artifactId>
+						<version>1.5.0-alpha.16</version>
+					</dependency>
+					<dependency>
+						<groupId>org.jruby</groupId>
+						<artifactId>jruby-complete</artifactId>
+						<version>1.7.21</version>
+					</dependency>
+				</dependencies>
+				<!-- Configure generic document generation settings -->
+				<configuration>
+					<sourceDirectory>${asciidoc.directory}</sourceDirectory>
+					<sourceDocumentName>ApiDocumentation.adoc</sourceDocumentName>
+				</configuration>
+				<!-- Since each execution can only handle one backend, run
+                     separate executions for each desired output type -->
+				<executions>
+					<execution>
+						<id>output-html</id>
+						<phase>test</phase>
+						<goals>
+							<goal>process-asciidoc</goal>
+						</goals>
+						<configuration>
+							<backend>html5</backend>
+							<outputDirectory>${html.directory}</outputDirectory>
+						</configuration>
+					</execution>
+
+					<execution>
+						<id>output-pdf</id>
+						<phase>test</phase>
+						<goals>
+							<goal>process-asciidoc</goal>
+						</goals>
+						<configuration>
+							<backend>pdf</backend>
+							<outputDirectory>${pdf.directory}</outputDirectory>
+						</configuration>
+					</execution>
+
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/backend/src/test/java/asegroup1/api/swagger/Swagger2MarkupTest.java
+++ b/backend/src/test/java/asegroup1/api/swagger/Swagger2MarkupTest.java
@@ -30,8 +30,15 @@ public class Swagger2MarkupTest {
 
   @Autowired private MockMvc mockMvc;
 
+  /**
+   * This Generates the swagger.json file in a unit tests and stores it in
+   * target/swagger/swagger.json so that it can be converted at compile time to
+   * static documentation
+   *
+   * @throws Exception
+   */
   @Test
-  public void createSpringfoxSwaggerJson() throws Exception {
+  public void generateSwaggerJson() throws Exception {
     String outputDir = "target/swagger/";
     MvcResult mvcResult =
         this.mockMvc

--- a/backend/src/test/java/asegroup1/api/swagger/Swagger2MarkupTest.java
+++ b/backend/src/test/java/asegroup1/api/swagger/Swagger2MarkupTest.java
@@ -1,0 +1,50 @@
+package asegroup1.api.swagger;
+
+import asegroup1.api.Application;
+import asegroup1.api.configs.SwaggerConfig;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.io.BufferedWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebAppConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {Application.class, SwaggerConfig.class})
+@AutoConfigureMockMvc
+public class Swagger2MarkupTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Test
+  public void createSpringfoxSwaggerJson() throws Exception {
+    String outputDir = "target/swagger/";
+    MvcResult mvcResult =
+        this.mockMvc
+            .perform(get("/v2/api-docs").accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    MockHttpServletResponse response = mvcResult.getResponse();
+    String swaggerJson = response.getContentAsString();
+    Files.createDirectories(Paths.get(outputDir));
+    try (BufferedWriter writer = Files.newBufferedWriter(
+             Paths.get(outputDir, "swagger.json"), StandardCharsets.UTF_8)) {
+      writer.write(swaggerJson);
+    }
+  }
+}


### PR DESCRIPTION
This auto generates some static documentation files when the backend is built.  Attached are the files produced
@Gregam3 Could you review /backend/src/test/java/asegroup1/api/swagger/Swagger2MarkupTest.java as I'm not 100% on how all the spring boot/ java ee stuff works
[docs.zip](https://github.com/Gregam3/ASEGroup1/files/2625765/docs.zip)
Closes #129 

Note: I had to add the environment variables to Travis otherwise the unit test would break when run on it.
